### PR TITLE
fix 2 typos to validate with

### DIFF
--- a/schema.rng
+++ b/schema.rng
@@ -297,7 +297,7 @@
   </define>
   <define name="rfc_822_opml_rx">
     <data type="string">
-      <param name="pattern">^((Mon|Tue|Wed|Thur|Fri|Sat|Sun), )?(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{2,4}) (\d{2}):(\d{2})(:(\d{2})?) (\S{1,4}|(\+|\-)\d{4})$</param>
+      <param name="pattern">((Mon|Tue|Wed|Thu|Fri|Sat|Sun), )?(\d+) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{2,4}) (\d{2}):(\d{2})(:(\d{2})?) (\S{1,4}|(\+|\-)\d{4})</param>
     </data>
   </define>
 </grammar>


### PR DESCRIPTION
```
$ xmllint --relaxng schema.rng tests/positive/dave_states.opml 
$ xmllint --version
xmllint: using libxml version 20708
   compiled with: Threads Tree Output Push Reader Patterns Writer SAXv1 FTP HTTP DTDValid HTML Legacy C14N Catalog XPath XPointer XInclude ISO8859X Unicode Regexps Automata Expr Schemas Schematron Modules Debug Zlib
```

P.S.: Always nice to find RelaxNG schemas.
